### PR TITLE
RSDEV-444: Upgrade galaxy-java-client to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.0.0]
+- Spring 6 / Hibernate 6 / Jakarta migration (RSDEV-444)
+- Upgrade to rspace-parent 3.0.0
+
 ## [1.1.0]
 - switch parent pom from rspace-os-parent to rspace-parent (updates/changes a lot of dependencies)
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.github.rspace-os</groupId>
     <artifactId>rspace-parent</artifactId>
-    <version>3.0.0</version>
+    <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>galaxy-java-client</artifactId>
-  <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
+  <version>2.0.0</version>
   <parent>
     <groupId>com.github.rspace-os</groupId>
     <artifactId>rspace-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>galaxy-java-client</artifactId>
-  <version>2.0.0</version>
+  <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
   <parent>
     <groupId>com.github.rspace-os</groupId>
     <artifactId>rspace-parent</artifactId>
@@ -132,7 +132,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-util</artifactId>
-      <version>2.0.0</version>
+      <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>galaxy-java-client</artifactId>
-  <version>1.1.0</version>
+  <version>2.0.0</version>
   <parent>
     <groupId>com.github.rspace-os</groupId>
     <artifactId>rspace-parent</artifactId>
-    <version>2.1.4</version>
+    <version>3.0.0</version>
   </parent>
 
   <repositories>
@@ -132,7 +132,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-core-util</artifactId>
-      <version>1.1.0</version>
+      <version>2.0.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Upgrade galaxy-java-client to 2.0.0 for Spring 6 / Jakarta migration (RSDEV-444).

Pom-only: bumps parent and `rspace-core-util`; no source changes required.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>